### PR TITLE
Fix early return in cajero

### DIFF
--- a/ejercicios/cajero.py
+++ b/ejercicios/cajero.py
@@ -30,6 +30,7 @@ def total_disponible():
 def retirar(monto):
     if monto > total_disponible():
         print("Error, no hay suficiente efectivo")
+        return
     
     saldo_retirar = monto
     while saldo_retirar > 0:

--- a/tests/test_cajero.py
+++ b/tests/test_cajero.py
@@ -1,0 +1,21 @@
+import importlib
+import builtins
+import os
+import sys
+
+# Add repository root to path so we can import cajero module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def test_retirar_insuficiente(monkeypatch, capsys):
+    # Ensure interactive input during module import doesn't block while importing
+    monkeypatch.setattr(builtins, 'input', lambda *args, **kwargs: '0')
+    cajero = importlib.import_module('ejercicios.cajero')
+    importlib.reload(cajero)
+    # Snapshot of cash before attempting withdrawal
+    available_before = cajero.disponible.copy()
+    cajero.retirar(cajero.total_disponible() + 1)
+    captured = capsys.readouterr()
+    assert "Error, no hay suficiente efectivo" in captured.out
+    # No cash should be dispensed
+    assert cajero.disponible == available_before


### PR DESCRIPTION
## Summary
- correct withdrawal logic in `cajero.retirar`
- add pytest to ensure function stops when funds are insufficient

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c96f6e2ac8329b44b66c048a07f78