### PR TITLE
Use environment variable for OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Para clonar y ejecutar los ejercicios localmente, sigue estos pasos:
 
 - Python 3.x
 - git
+- Variable de entorno `OPENAI_API_KEY` para el ejemplo de ChatGPT
 
 ### Clonar el repositorio
 
@@ -36,3 +37,12 @@ def mi_funcion(argumentos):
 ¡Espero que encuentres estos ejercicios útiles para mejorar tus habilidades de programación en Python! Si tienes alguna pregunta o sugerencia, no dudes en abrir un issue o contactarme: [jimcostdev.com](https://www.jimcostdev.com/)
 
 ¡Gracias por visitar y Happy Coding! 🚀
+
+## Uso del ejemplo de ChatGPT
+
+Para ejecutar `ejercicios/chatgpt_desde_python/chatgpt.py` necesitas definir la variable de entorno `OPENAI_API_KEY` con tu clave de OpenAI antes de iniciar el script:
+
+```bash
+export OPENAI_API_KEY="tu-clave"
+python ejercicios/chatgpt_desde_python/chatgpt.py
+```

--- a/ejercicios/chatgpt_desde_python/chatgpt.py
+++ b/ejercicios/chatgpt_desde_python/chatgpt.py
@@ -1,9 +1,12 @@
 """
     1. Instalar openai:
         pip install openai
+    2. Antes de ejecutar, define tu clave de API:
+        export OPENAI_API_KEY="tu-clave"
 """
+import os
 import openai
-openai.api_key = "key"
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 while True:
     try:


### PR DESCRIPTION
## Summary
- use OPENAI_API_KEY environment variable in chatgpt.py
- document OPENAI_API_KEY usage in README

## Testing
- `python -m py_compile ejercicios/chatgpt_desde_python/chatgpt.py`

------
https://chatgpt.com/codex/tasks/task_e_685c95c585288329bec7c9c75b5fc71f