### PR TITLE
Fix typo in version_python header

### DIFF
--- a/ejercicios/version_python.py
+++ b/ejercicios/version_python.py
@@ -1,4 +1,4 @@
-# Mostar la versión actual de python instalada
+# Mostrar la versión actual de Python instalada
 import sys
 print('Mi version actual de python es: {}'.format(sys.version))
 print('Versionamiento semantico: {}'.format(sys.version_info))


### PR DESCRIPTION
## Summary
- update header comment of `version_python.py`

## Testing
- `python3 -m py_compile ejercicios/version_python.py`


------
https://chatgpt.com/codex/tasks/task_e_685c9bc2a1f08329ae5ed38267d8e6a0